### PR TITLE
Represent compilation error as Diagnostics instance

### DIFF
--- a/src/impl/dts-transformer.ts
+++ b/src/impl/dts-transformer.ts
@@ -19,10 +19,10 @@ export class DtsTransformer {
     this._index = new ModuleIndex(_source);
   }
 
-  async transform(): Promise<FlatDts> {
+  async transform(initialDiagnostics: readonly ts.Diagnostic[]): Promise<FlatDts> {
 
     const topLevel = await this._transform();
-    const diagnostics: ts.Diagnostic[] = [];
+    const diagnostics: ts.Diagnostic[] = initialDiagnostics.slice();
     const files = this._emitFiles(topLevel, diagnostics);
 
     return flatDts(files, diagnostics);


### PR DESCRIPTION
In case the `program.emit()` throws an error, wrap the thrown error into Diagnostics
and report it normally. There is a chance the `.d.ts` is already generated in this case.