### PR TITLE
Allow entries to have the same alias

### DIFF
--- a/src/impl/dts-transformer.ts
+++ b/src/impl/dts-transformer.ts
@@ -176,11 +176,11 @@ export class DtsTransformer {
     const { text: from } = moduleSpecifier as ts.StringLiteral;
     const fromModule = await this._index.byName(from);
 
-    if (fromModule !== enclosing) {
+    if (fromModule.declareAs !== enclosing.declareAs) {
       // Import from another module.
 
       if (fromModule.isInternal) {
-        // Drop the imports from internal modules.
+        // Drop import from internal module.
         return noneTransformed();
       }
 
@@ -264,11 +264,11 @@ export class DtsTransformer {
     const { text: from } = moduleSpecifier as ts.StringLiteral;
     const fromModule = await this._index.byName(from);
 
-    if (fromModule !== enclosing) {
+    if (fromModule.declareAs !== enclosing.declareAs) {
       // Export from another module.
 
       if (fromModule.isInternal) {
-        // Drop the imports from internal modules.
+        // Drop export from internal module.
         return noneTransformed();
       }
 
@@ -286,7 +286,7 @@ export class DtsTransformer {
       };
     }
 
-    // Import from the same module.
+    // Export from the same module.
     const { exportClause } = statement;
 
     if (!exportClause) {


### PR DESCRIPTION
When multiple entries declared as the same sub-module, the resulting `.d.ts`
file could contain declarations like this:

```typescript
declare module "my-module/sub-module" {
  export * from "my-module/sub-module";
}
```

This PR removes such declarations, as they are not needed.
