### PR TITLE
Make triple-slash file references optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,18 @@ Configuration Options
 
   A map of entry name declarations ([see below](#multiple-entries)).
   
-- `lib` Whether to add [triple-slash] directives to refer the libraries used.
+- `lib` - Whether to add [triple-slash] directives to refer the libraries used.
 
   Allowed values:
   - `true` to add an entry for each referred library from `lib` compiler option,
   - `false` (the default) to not add any library references,
   - an explicit list of libraries to refer.
+
+- `refs` - Whether to add file references.
+
+  A file reference is added when one entry refers another one.
+
+  `true` by default.
   
 - `external` - External module names.
 
@@ -227,6 +233,8 @@ export default {
             as: 'web',              // belong to `my-package/web` sub-module.
                                     // (Would be `my-package/browser` if omitted)
             lib: 'DOM',             // Add `DOM` library reference.
+            refs: false,            // Do not add triple-slash file references to other entries.
+                                    // Otherwise, a file reference will be added for each entry this one refers.
             file: 'web/index.d.ts', // Write type definitions to separate `.d.ts` file.
                                     // (Would be written to main `index.d.ts` if omitted) 
           },

--- a/src/api/flat-dts.ts
+++ b/src/api/flat-dts.ts
@@ -98,6 +98,15 @@ export namespace FlatDts {
     readonly lib?: boolean | string | readonly string[];
 
     /**
+     * Whether to add file references.
+     *
+     * A file reference is added when one entry refers another one.
+     *
+     * @defaultValue `true`
+     */
+    readonly refs?: boolean;
+
+    /**
      * External module names.
      *
      * An array of external module names and their [glob] patterns. These names won't be changed during flattening
@@ -154,6 +163,15 @@ export namespace FlatDts {
      * When omitted the contents are merged into main `.d.ts.` file.
      */
     readonly file?: string;
+
+    /**
+     * Whether to add file references.
+     *
+     * A file reference is added for each entry this one refers.
+     *
+     * @defaultValue Inherited from {@link Options.refs `refs` flattening option}.
+     */
+    readonly refs?: boolean;
 
   }
 

--- a/src/impl/dts-content.ts
+++ b/src/impl/dts-content.ts
@@ -45,13 +45,15 @@ export class DtsContent {
   }
 
   private _prelude(printer: DtsPrinter): void {
-    for (const ref of this._refs) {
+    if (this.module.refs) {
+      for (const ref of this._refs) {
 
-      const path = this.module.pathTo(ref);
+        const path = this.module.pathTo(ref);
 
-      if (path) {
-        // No need to refer to itself.
-        printer.text(`/// <reference path="${path}" />`).nl();
+        if (path) {
+          // No need to refer itself.
+          printer.text(`/// <reference path="${path}" />`).nl();
+        }
       }
     }
   }


### PR DESCRIPTION
Inside pnpm workspace installation a reference to upper-level `..index.d.ts` breaks `rollup-plugin-typescript2` and `@rollup/plugin-typescript`. `tsc` still works. Don't know the reason, but removing such reference fixes the issue.
Making file references optional allows to work the issue around.