### PR TITLE
Do not force `preserveSymlinks` compiler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,8 +315,6 @@ So, here what this plugin is doing:
      noEmit: false,
      // Skip code generation when error occurs
      noEmitOnError: true,
-     // Ensure TS2742 errors are visible
-     preserveSymlinks: true,
      // Ignore errors in library type definitions
      skipLibCheck: true,
      // Always strip internal exports

--- a/src/impl/dts-setup.ts
+++ b/src/impl/dts-setup.ts
@@ -20,8 +20,6 @@ const MANDATORY_COMPILER_OPTIONS: ts.CompilerOptions = {
   noEmit: false,
   // Skip code generation when error occurs
   noEmitOnError: true,
-  // Ensure TS2742 errors are visible
-  preserveSymlinks: true,
   // Ignore errors in library type definitions
   skipLibCheck: true,
   // Always strip internal exports


### PR DESCRIPTION
Make it configurable instead.
