### PR TITLE
Use `target: "System"`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '12'
+        node-version: '14'
     - name: Install pnpm
       run: npm i -g pnpm
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ So, here what this plugin is doing:
      // Single file emission is impossible with this flag set
      isolatedModules: false,
      // Generate single file
-     module: "None",
+     // `System`, in contrast to `None`, permits the use of `import.meta`
+     module: "System",
      // Always emit
      noEmit: false,
      // Skip code generation when error occurs

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "all": "run-z +z build,lint,test",
-    "bootstrap": "rollup --config ./rollup.config.js",
+    "bootstrap": "rollup -c",
     "build": "run-z +z bootstrap dts",
     "ci:all": "run-z all +cmd:jest/--ci/--runInBand",
     "clean": "run-z +z --then shx rm -rf 'index.d.ts?(.map)' '*/index.d.ts?(.map)' dist target",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,11 +1,13 @@
 import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
-import { builtinModules } from 'module';
+import { builtinModules, createRequire } from 'module';
 import path from 'path';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 import ts from 'rollup-plugin-typescript2';
 import typescript from 'typescript';
-import pkg from './package.json';
+
+const req = createRequire(import.meta.url);
+const pkg = req('./package.json');
 
 export default {
   input: {

--- a/src/impl/dts-setup.ts
+++ b/src/impl/dts-setup.ts
@@ -15,7 +15,8 @@ const MANDATORY_COMPILER_OPTIONS: ts.CompilerOptions = {
   // Single file emission is impossible with this flag set
   isolatedModules: false,
   // Generate single file
-  module: ts.ModuleKind.None,
+  // `System`, in contrast to `None`, permits the use of `import.meta`
+  module: ts.ModuleKind.System,
   // Always emit
   noEmit: false,
   // Skip code generation when error occurs

--- a/src/tests/imports/tsconfig.json
+++ b/src/tests/imports/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext"
+  },
   "files": [
     "./importer.ts"
   ],


### PR DESCRIPTION
- Use `target: "System"`.
  This allows to transpile TypeScript with e.g. `import.meta`, unlike `target: "None"`
- Build with Node 14
- ESM Rollup config
