### PR TITLE
Respect output directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "peerDependencies": {
-    "rollup": "^2.56.1",
+    "rollup": "^2.56.2",
     "typescript": "4.1.5 - 4.4"
   },
   "peerDependenciesMeta": {
@@ -64,7 +64,7 @@
     "remark-lint-list-item-indent": "^2.0.1",
     "remark-lint-no-shortcut-reference-link": "^2.0.1",
     "remark-preset-lint-recommended": "^5.0.0",
-    "rollup": "^2.56.1",
+    "rollup": "^2.56.2",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "rollup-plugin-typescript2": "^0.30.0",
     "run-z": "=1.9.2-bootstrap",

--- a/src/api/flat-dts.ts
+++ b/src/api/flat-dts.ts
@@ -51,28 +51,28 @@ export namespace FlatDts {
      *
      * @defaultValue `"tsconfig.json"`
      */
-    readonly tsconfig?: string;
+    readonly tsconfig?: string | undefined;
 
     /**
      * TypeScript compiler options to apply.
      *
      * Override the options from {@link tsconfig}.
      */
-    readonly compilerOptions?: ts.CompilerOptions;
+    readonly compilerOptions?: ts.CompilerOptions | undefined;
 
     /**
      * Output `.d.ts` file name relative to output directory.
      *
      * @defaultValue `index.d.ts`
      */
-    readonly file?: string;
+    readonly file?: string | undefined;
 
     /**
      * The module name to replace flattened module declarations with.
      *
      * @defaultValue Package name extracted from `package.json` found in current directory.
      */
-    readonly moduleName?: string;
+    readonly moduleName?: string | undefined;
 
     /**
      * Module entries.
@@ -95,7 +95,7 @@ export namespace FlatDts {
      *
      * @defaultValue `false`
      */
-    readonly lib?: boolean | string | readonly string[];
+    readonly lib?: boolean | string | readonly string[] | undefined;
 
     /**
      * Whether to add file references.
@@ -104,7 +104,7 @@ export namespace FlatDts {
      *
      * @defaultValue `true`
      */
-    readonly refs?: boolean;
+    readonly refs?: boolean | undefined;
 
     /**
      * External module names.
@@ -116,7 +116,7 @@ export namespace FlatDts {
      *
      * [glob]: https://www.npmjs.com/package/micromatch
      */
-    readonly external?: string | readonly string[];
+    readonly external?: string | readonly string[] | undefined;
 
     /**
      * Internal module names.
@@ -126,7 +126,7 @@ export namespace FlatDts {
      *
      * [glob]: https://www.npmjs.com/package/micromatch
      */
-    readonly internal?: string | readonly string[];
+    readonly internal?: string | readonly string[] | undefined;
 
   }
 
@@ -142,7 +142,7 @@ export namespace FlatDts {
      *
      * @defaultValue The same as {@link name}.
      */
-    readonly as?: string;
+    readonly as?: string | undefined;
 
     /**
      * Whether to add [triple-slash](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
@@ -155,14 +155,14 @@ export namespace FlatDts {
      *
      * @defaultValue Inherited from {@link Options.lib `lib` flattening option}.
      */
-    readonly lib?: boolean | string | readonly string[];
+    readonly lib?: boolean | string | readonly string[] | undefined;
 
     /**
      * Output `.d.ts` file name relative to output directory.
      *
      * When omitted the contents are merged into main `.d.ts.` file.
      */
-    readonly file?: string;
+    readonly file?: string | undefined;
 
     /**
      * Whether to add file references.
@@ -171,7 +171,7 @@ export namespace FlatDts {
      *
      * @defaultValue Inherited from {@link Options.refs `refs` flattening option}.
      */
-    readonly refs?: boolean;
+    readonly refs?: boolean | undefined;
 
   }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,6 +2,7 @@
  * @packageDocumentation
  * @module Module rollup-plugin-flat-dts
  */
+import { relative, resolve } from 'path';
 import type { OutputPlugin } from 'rollup';
 import type { FlatDts } from './api';
 import { emitFlatDts } from './api';
@@ -20,7 +21,14 @@ export default function flatDtsPlugin(dtsOptions?: FlatDts.Options): OutputPlugi
 
     name: 'flat-dts',
 
-    async generateBundle(): Promise<void> {
+    async generateBundle({ dir }): Promise<void> {
+
+      let assetPath = (filePath: string): string => filePath;
+
+      if (dir != null) {
+        dtsOptions = dtsOptionsRelativeToDir(dir, dtsOptions);
+        assetPath = filePath => relative(dir, filePath);
+      }
 
       const dts = await emitFlatDts(dtsOptions);
 
@@ -31,10 +39,39 @@ export default function flatDtsPlugin(dtsOptions?: FlatDts.Options): OutputPlugi
       dts.files.forEach(({ path, content }) => {
         this.emitFile({
           type: 'asset',
-          fileName: path,
+          fileName: assetPath(path),
           source: content,
         });
       });
     },
+  };
+}
+
+function dtsOptionsRelativeToDir(dir: string, dtsOptions: FlatDts.Options = {}): FlatDts.Options {
+
+  const { file = 'index.d.ts', entries = {} } = dtsOptions;
+
+  return {
+    ...dtsOptions,
+    file: relative(process.cwd(), resolve(dir, file)),
+    entries: Object.fromEntries(
+        Object
+            .entries(entries)
+            .map(([key, dtsEntry = {}]) => [key, dtsEntryRelativeToDir(dir, dtsEntry)]),
+    ),
+  };
+}
+
+function dtsEntryRelativeToDir(dir: string, dtsEntry: FlatDts.EntryDecl = {}): FlatDts.EntryDecl {
+
+  const { file } = dtsEntry;
+
+  if (file == null) {
+    return dtsEntry;
+  }
+
+  return {
+    ...dtsEntry,
+    file: relative(process.cwd(), resolve(dir, file)),
   };
 }


### PR DESCRIPTION
- TypeScript 4.4-compatible type definitions
- Compute file paths relatively to CWD to properly evaluate `sourceRoot` of generated declaration map.
